### PR TITLE
Task #295 changed the global init to a more robust init all variables. I think …

### DIFF
--- a/LeNet-Lab-Solution.ipynb
+++ b/LeNet-Lab-Solution.ipynb
@@ -373,7 +373,7 @@
    "outputs": [],
    "source": [
     "with tf.Session() as sess:\n",
-    "    sess.run(tf.global_variables_initializer())\n",
+    "    tf.initialize_all_variables().run()\n",
     "    num_examples = len(X_train)\n",
     "    \n",
     "    print(\"Training...\")\n",


### PR DESCRIPTION
…most students were having problems because the global init is a new addition to tensorflow v12. I tried using tf v12 and

while the global init may have worked there were other issues such as using the import data_input. Using the init all variables command works well though and I think it will be good for
most students setups. The init is not needed in the final code block for running test accuracy if it is already excuted during the training code block.