### PR TITLE
update api call with named argument

### DIFF
--- a/LeNet-Lab.ipynb
+++ b/LeNet-Lab.ipynb
@@ -287,7 +287,7 @@
     "rate = 0.001\n",
     "\n",
     "logits = LeNet(x)\n",
-    "cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits, one_hot_y)\n",
+    "cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=logits, labels=one_hot_y)\n",
     "loss_operation = tf.reduce_mean(cross_entropy)\n",
     "optimizer = tf.train.AdamOptimizer(learning_rate = rate)\n",
     "training_operation = optimizer.minimize(loss_operation)"


### PR DESCRIPTION
It seems softmax_cross_entropy_with_logits api call is updated in TF1.0

Current code will cause valueError: Only call softmax_cross_entropy_with_logits with named arguments (labels=..., logits=..., ...)

References:
[TensorFlow wavenet issues](https://github.com/ibab/tensorflow-wavenet/issues/223)
[Stackoverflow](http://stackoverflow.com/questions/42296782/valueerror-when-executing-softmax-cross-entropy-with-logits)