### PR TITLE
fix the error when using tensorflow 1.0

### DIFF
--- a/LeNet-Lab-Solution.ipynb
+++ b/LeNet-Lab-Solution.ipynb
@@ -309,7 +309,7 @@
     "rate = 0.001\n",
     "\n",
     "logits = LeNet(x)\n",
-    "cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits, one_hot_y)\n",
+    "cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=logits, labels=one_hot_y)\n",
     "loss_operation = tf.reduce_mean(cross_entropy)\n",
     "optimizer = tf.train.AdamOptimizer(learning_rate = rate)\n",
     "training_operation = optimizer.minimize(loss_operation)"
@@ -442,10 +442,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.2"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In tensorflow 1.0, tf.nn.softmax_cross_entropy_with_logits() only call
with named arguments

Old:
cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits,
one_hot_y)

New:
cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=logits,
labels=one_hot_y)

Error messages:
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-8-967bb02bb6da> in <module>()
      2 
      3 logits = LeNet(x)
----> 4 cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits, one_hot_y)
      5 loss_operation = tf.reduce_mean(cross_entropy)
      6 optimizer = tf.train.AdamOptimizer(learning_rate = rate)

D:\Anaconda3\envs\tensorflow\lib\site-packages\tensorflow\python\ops\nn_ops.py in softmax_cross_entropy_with_logits(_sentinel, labels, logits, dim, name)
   1576   """
   1577   _ensure_xent_args("softmax_cross_entropy_with_logits", _sentinel,
-> 1578                     labels, logits)
   1579 
   1580   # TODO(pcmurray) Raise an error when the labels do not sum to 1. Note: This

D:\Anaconda3\envs\tensorflow\lib\site-packages\tensorflow\python\ops\nn_ops.py in _ensure_xent_args(name, sentinel, labels, logits)
   1531   if sentinel is not None:
   1532     raise ValueError("Only call `%s` with "
-> 1533                      "named arguments (labels=..., logits=..., ...)" % name)
   1534   if labels is None or logits is None:
   1535     raise ValueError("Both labels and logits must be provided.")

ValueError: Only call `softmax_cross_entropy_with_logits` with named arguments (labels=..., logits=..., ...)