### PR TITLE
Update LeNet-Lab.ipynb

### DIFF
--- a/LeNet-Lab.ipynb
+++ b/LeNet-Lab.ipynb
@@ -287,7 +287,7 @@
     "rate = 0.001\n",
     "\n",
     "logits = LeNet(x)\n",
-    "cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits, one_hot_y)\n",
+    "cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=logits, labels=one_hot_y)\n",
     "loss_operation = tf.reduce_mean(cross_entropy)\n",
     "optimizer = tf.train.AdamOptimizer(learning_rate = rate)\n",
     "training_operation = optimizer.minimize(loss_operation)"


### PR DESCRIPTION
/usr/local/lib/python3.6/site-packages/tensorflow/python/ops/nn_ops.py in _ensure_xent_args(name, sentinel, labels, logits)
   1531   if sentinel is not None:
   1532     raise ValueError("Only call `%s` with "
-> 1533                      "named arguments (labels=..., logits=..., ...)" % name)
   1534   if labels is None or logits is None:
   1535     raise ValueError("Both labels and logits must be provided.")

ValueError: Only call `softmax_cross_entropy_with_logits` with named arguments (labels=..., logits=..., ...)